### PR TITLE
Change setDefaultOptions to configureOptions

### DIFF
--- a/src/KPhoen/Bundle/MultipleUploadableBundle/Form/Type/BikeImageType.php
+++ b/src/KPhoen/Bundle/MultipleUploadableBundle/Form/Type/BikeImageType.php
@@ -4,7 +4,7 @@ namespace KPhoen\Bundle\MultipleUploadableBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class BikeImageType extends AbstractType
 {
@@ -20,7 +20,7 @@ class BikeImageType extends AbstractType
         ;
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'KPhoen\Bundle\MultipleUploadableBundle\Entity\BikeImage',


### PR DESCRIPTION
Since setDefaultOptions has been deprecated (https://symfony.com/blog/new-in-symfony-2-7-form-and-validator-updates#deprecated-setdefaultoptions-in-favor-of-configureoptions) and remove in Symfony 3, we should use configureOptions in place of.